### PR TITLE
Development python label test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ src_paths = [".", "tests/"]
 
 [tool.pytest.ini_options]
 pythonpath = "."
-testpaths = ["tests/"]
+testpaths = ["test/"]
 xfail_strict = true
 markers = ["no_test_env"]
 

--- a/randopy/rando.py
+++ b/randopy/rando.py
@@ -1,4 +1,5 @@
 import logging
+import random
 from datetime import datetime
 from pathlib import Path
 
@@ -30,3 +31,7 @@ def custom_namer(name: str) -> str:
         raise ValueError(name)
     date = str(datetime.now().date())
     return f"{stem}.{date}{name_path.suffix}"
+
+
+def roll_d6(count: int) -> list[int]:
+    return [random.randint(1, 6) for _ in range(1, count+1)]

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -7,6 +7,7 @@ from hypothesis import strategies as st
 from randopy import rando
 
 
+@pytest.mark.skip(reason="Too slow")
 class TestCustomNamer:
     @given(
         stem=st.text(min_size=1, alphabet=st.characters(categories=["L", "N", "S"])),
@@ -71,3 +72,10 @@ class TestCustomNamer:
         assume("." not in name)
         with pytest.raises(ValueError):
             rando.custom_namer(name)
+
+
+class TestRollD6:
+    @given(test_count=st.integers(min_value=0))
+    def test_count(self, test_count: int):
+        result = rando.roll_d6(count=test_count)
+        assert len(result) == test_count


### PR DESCRIPTION
Should be automatically labelled `dependencies:development`
Based on [this](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#label-a-pull-request)

Working now